### PR TITLE
Fixes for latest Nim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ Temporary Items
 nimcache
 bug
 tester/temp.png
+tester/rainbow.png
+tester/test
+tester/testCodec
+tester/testSuite

--- a/nimPNG.nim
+++ b/nimPNG.nim
@@ -26,7 +26,7 @@
 #-------------------------------------
 
 import streams, endians, tables, hashes, math
-import private.buffer, private.nimz
+import private/buffer, private/nimz
 
 const
   NIM_PNG_VERSION = "0.2.1"
@@ -330,16 +330,14 @@ proc copyTo*(src, dest: PNGColorMode) =
   dest.colorType = src.colorType
   dest.bitDepth = src.bitDepth
   dest.paletteSize = src.paletteSize
-  if src.palette != nil:
-    newSeq(dest.palette, src.paletteSize)
-    for i in 0..src.palette.len-1: dest.palette[i] = src.palette[i]
+  newSeq(dest.palette, src.paletteSize)
+  for i in 0..src.palette.len-1: dest.palette[i] = src.palette[i]
 
 proc newColorMode*(mode: PNGColorMode): PNGColorMode =
   new(result)
   mode.copyTo(result)
 
 proc addPalette*(mode: PNGColorMode, r, g, b, a: int) =
-  if mode.palette == nil: mode.palette = @[]
   mode.palette.add RGBA8(r: chr(r), g: chr(g), b: chr(b), a: chr(a))
   mode.paletteSize = mode.palette.len
 
@@ -1938,7 +1936,7 @@ proc processingAPNG(apng: APNG, colorType: PNGcolorType, bitDepth: int) =
   if apng.png.firstFrameIsDefaultImage:
     start = 1
     # IDAT already processed, so we add a dummy here
-    frameData.add string(nil)
+    frameData.add ""
 
   for x in apng.png.apngChunks:
     if x.chunkType == fcTL:
@@ -2155,7 +2153,7 @@ proc makePNGEncoder*(): PNGEncoder =
   s.modeIn = newColorMode()
   s.modeOut = newColorMode()
   s.forcePalette = false
-  s.predefinedFilters = nil
+  s.predefinedFilters = ""
   s.addID = false
   s.textCompression = true
   s.interlaceMethod = IM_NONE
@@ -3113,7 +3111,7 @@ proc addChunkacTL(png: PNG, numFrames, numPlays: int) =
 
 proc addChunkfcTL(png: PNG, chunk: APNGFrameControl, sequenceNumber: int) =
   chunk.chunkType = fcTL
-  if chunk.data.isNil:
+  if chunk.data == "":
     chunk.data = newStringOfCap(26)
   chunk.sequenceNumber = sequenceNumber
   png.chunks.add chunk
@@ -3319,7 +3317,7 @@ proc prepareAPNG*(colorType: PNGcolorType, bitDepth, numPlays: int, settings = P
   png.isAPNG = true
   png.apngChunks = @[]
   png.apngPixels = @[]
-  png.pixels = nil
+  png.pixels = ""
   png.firstFrameIsDefaultImage = false
   png.width = 0
   png.height = 0
@@ -3337,7 +3335,7 @@ proc addDefaultImage*(png: PNG, input: string, width, height: int, ctl = APNGFra
   png.firstFrameIsDefaultImage = ctl != nil
   if ctl != nil:
     png.apngChunks.add ctl
-    png.apngPixels.add nil # add dummy
+    png.apngPixels.add "" # add dummy
     result = result and (ctl.xOffset == 0)
     result = result and (ctl.yOffset == 0)
     result = result and (ctl.width == width)
@@ -3375,7 +3373,7 @@ proc encodeAPNG*(png: PNG): string =
     result = s.data
   except:
     debugEcho getCurrentExceptionMsg()
-    result = nil
+    result = ""
 
 when not defined(js):
   proc saveAPNG*(png: PNG, fileName: string): bool =

--- a/nimPNG.nimble
+++ b/nimPNG.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.2.2"
+version       = "0.2.3"
 author        = "Andri Lim"
 description   = "PNG encoder and decoder"
 license       = "MIT"

--- a/private/buffer.nim
+++ b/private/buffer.nim
@@ -20,7 +20,11 @@ proc subbuffer*[T](b: Buffer[T], offset: int): Buffer[T] =
     shallowCopy(result.data, b.data)
     result.offset = b.offset + offset
 
-template isNil*[T](b: Buffer[T]): bool = b.data.isNil
+template isNil*[T](b: Buffer[T]): bool =
+    when T is (string or seq):
+        b.data.len == 0
+    else:
+        b.data.isNil
 
 template copyElements*[T](dst: var Buffer[T], src: Buffer[T], count: int) =
     when defined(js):

--- a/tester/minibmp.nim
+++ b/tester/minibmp.nim
@@ -19,7 +19,7 @@ proc newBMP*(w, h: int): BMP =
   result.height = h
   result.data = newString(w * h * 3)
 
-proc write*(s: Stream, bmp: BMP) =
+proc writeBMP*(s: Stream, bmp: BMP) =
   let stride    = 4 * ((bmp.width * 24 + 31) div 32)
   let imageData = stride * bmp.height
   let offset    = 54
@@ -43,7 +43,7 @@ proc write*(s: Stream, bmp: BMP) =
 
   let bytesPerRow = bmp.width * 3
   let paddingLen  = stride - bytesPerRow
-  let padding     = if paddingLen > 0: newString(paddingLen) else: nil
+  let padding     = if paddingLen > 0: newString(paddingLen) else: ""
 
   for i in 0..bmp.height-1:
     s.writeData(addr(bmp.data[i * bytesPerRow]), bytesPerRow)

--- a/tester/test.nim
+++ b/tester/test.nim
@@ -2,11 +2,11 @@ import nimPNG, streams, minibmp, os, strutils
 
 proc write(bmp: BMP): string =
   var s = newStringStream()
-  s.write(bmp)
+  s.writeBMP(bmp)
   result = s.data
 
 proc toBMP(png: PNGResult, fileName: string) =
-  if png.frames != nil:
+  if png.frames != @[]:
     var frame = 0
     for x in png.frames:
       var bmp = newBMP(x.ctl.width, x.ctl.height)

--- a/tester/testSuite.nim
+++ b/tester/testSuite.nim
@@ -15,7 +15,7 @@ proc loadPNG(fileName: string): BMP =
 
 proc write(bmp: BMP): string =
   var s = newStringStream()
-  s.write(bmp)
+  s.writeBMP(bmp)
   result = s.data
 
 proc convert(dir: string) =


### PR DESCRIPTION
This fixes https://github.com/jangko/nimPNG/issues/21

nil strings and seqs do not exist anymore, and the code has been changed accordingly, to use "" and @[] in their place (internally these do not allocate anyway).

I have mostly made mechanical changes, but the tests all seem to be fine. A minor issue that I found is that (due to some unrelated change?) the correct overload of `write(s: Stream, bmp: BMP)` was not selected - instead Nim insisted to select the `write` function in the `streams` module. I changed the name to `writeBMP` instead - this is only used in tests anyway.

I also changed the imports to use `/` instead of `.`, since the latter is deprecated