### PR TITLE
nicematch range up to 258

### DIFF
--- a/nimPNG/nimz.nim
+++ b/nimPNG/nimz.nim
@@ -126,7 +126,7 @@ type
     use_lz77: bool
     windowsize: range[2..32768]
     minmatch: range[3..258]
-    nicematch: range[3..358]
+    nicematch: range[3..258]
     lazymatching: bool
     bits: BitStream
     data: string


### PR DESCRIPTION
`if(nicematch > MAX_SUPPORTED_DEFLATE_LENGTH) nicematch = MAX_SUPPORTED_DEFLATE_LENGTH;`

https://github.com/google/zopfli/blob/ebc6ffebdc6625e3ae49bedccdbc447e4a495bfe/src/zopflipng/lodepng/lodepng.cpp#L1631

`static const size_t MAX_SUPPORTED_DEFLATE_LENGTH = 258;`

https://github.com/google/zopfli/blob/ebc6ffebdc6625e3ae49bedccdbc447e4a495bfe/src/zopflipng/lodepng/lodepng.cpp#L1466