### PR TITLE
avoid nzCompressInit ambiguous call when included

### DIFF
--- a/nimPNG/filters.nim
+++ b/nimPNG/filters.nim
@@ -285,7 +285,7 @@ proc filterBruteForce*[T](output: var openArray[T], input: openArray[T], w, h, b
           byteWidth, lineTs, PNGFilter(fType))
 
       size[fType] = 0
-      var nz = nzCompressInit(attempt[fType])
+      var nz = nimz.nzCompressInit(attempt[fType])
       let data = zlib_compress(nz)
       size[fType] = data.len
 


### PR DESCRIPTION
I include it in [zopflipng](https://github.com/bung87/zopflipng)
I have to, it use some symbols not exported, it's hard to figure these symbols one by one.

```nim
include nimPNG
include nimPNG/nimz
```

```
/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/nimble_4343/githubcom_bung87crowncli/src/crowncli.nim(69, 32) template/generic instantiation of `savePNG32` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(3145, 20) template/generic instantiation of `savePNG32Impl` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(3017, 16) template/generic instantiation of `savePNGImpl` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(3008, 26) template/generic instantiation of `encodePNG` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(2973, 21) template/generic instantiation of `encodePNG` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(2960, 17) template/generic instantiation of `encoderCore` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(2879, 18) template/generic instantiation of `frameConvert` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(2839, 24) template/generic instantiation of `preProcessScanLines` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(2648, 13) template/generic instantiation of `filter` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG.nim(2628, 39) template/generic instantiation of `filterBruteForce` from here
/Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG/filters.nim(288, 30) Error: ambiguous call; both nimz.nzCompressInit(input: seq[byte], mode: nzCompMode) [template declared in /Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG/nimz.nim(1229, 10)] and zopflipng.nzCompressInit(input: seq[byte], mode: nzCompMode) [template declared in /Users/runner/.nimble/pkgs/nimPNG-0.3.2/nimPNG/nimz.nim(1229, 10)] match for: (seq[byte])
```