### PR TITLE
make `getUnderlyingType` work with type argument

### DIFF
--- a/nimPNG.nim
+++ b/nimPNG.nim
@@ -274,6 +274,7 @@ proc crc32(crc: uint32, buf: string): uint32 =
   result = not crcu32
 
 template getUnderlyingType[T](_: openArray[T]): untyped = T
+template getUnderlyingType[T](_: type openArray[T]): untyped = T
 
 template newStorage[T](size: int): auto =
   when T is string:


### PR DESCRIPTION
Below `newStorage[T]` and `newStorageOfCap[T]` call `getUnderlyingType(T)`, which shouldn't work because `T` is a type and `getUnderlyingType` takes an `openArray` argument. However it works due to a [Nim bug](https://github.com/nim-lang/Nim/issues/20033) where `T` is treated as a *value* of its type.

To make this work with and without the bug fixed, add an additional `getUnderlyingType` overload that takes a `type openArray` parameter instead.